### PR TITLE
ci: remove PyPI publish

### DIFF
--- a/.github/workflows/reusable_publish.yml
+++ b/.github/workflows/reusable_publish.yml
@@ -185,7 +185,3 @@ jobs:
           export TWINE_PASSWORD=`aws codeartifact get-authorization-token --domain ${{ secrets.CUSTOMER_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text`
           export TWINE_REPOSITORY_URL=`aws codeartifact get-repository-endpoint --domain ${{ secrets.CUSTOMER_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --repository ${{ secrets.CUSTOMER_REPOSITORY }} --format pypi --query repositoryEndpoint --output text`
           twine upload dist/*
-
-      # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
PyPI publishing does not support reusable workflows, there is an open issue to add support:

https://github.com/pypi/warehouse/issues/11096

### What was the solution? (How)
For now we need to keep publishing to pypi as a job in the publish workflow file of each repository so that it can authenticate to publish.


### What is the impact of this change?
Move PyPI publishing job back to each repository instead of using a reusable workflow

### How was this change tested?
n/a - removing because its a known failure.

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*