### PR TITLE
ci: add reusable codeql workflow

### DIFF
--- a/.github/workflows/reusable_codeql.yml
+++ b/.github/workflows/reusable_codeql.yml
@@ -1,0 +1,37 @@
+name: "CodeQL"
+
+on:
+  workflow_call:
+    inputs:
+        languages:
+          description: "Provide a comma seperated list. Supported languages are: python, typescript, javascript, go, java, cpp, csharp, ruby."
+          required: false
+          type: string
+          default: "python"
+        mode:
+          description: "Supports none, autobuild or manual." 
+          required: false
+          type: string
+          default: none
+
+jobs:
+  analyze:
+    name: Analyze (${{inputs.languages}})
+    runs-on: ubuntu-latest
+    permissions:
+      # required for all workflows
+      security-events: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    
+     # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        queries: +security-and-quality
+        languages: ${{inputs.languages}}
+        build-mode: ${{inputs.mode }}
+    
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to run codeql jobs on PRs

### What was the solution? (How)
Add a reusable codeql workflow that can be used by openjd repositories.

### What is the impact of this change?
workflow for running codeql

### How was this change tested?
Will be tested using other repositories once the change has been merged.

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*