### PR TITLE
chore: update workflows to tag based release

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -1,0 +1,40 @@
+name: 'Check Release Prerequisites'
+description: 'Checks if a release already exists for a tag and verifies the commit author'
+
+inputs:
+  tag:
+    description: 'The tag to check'
+    required: true
+  expected_author:
+    description: 'The expected email of the commit author'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: refs/tags/${{ inputs.tag }}
+        fetch-depth: 0
+    
+    - name: Check if release exists and verify author
+      shell: bash
+      run: |
+        echo "Checking if release exists for tag ${{ inputs.tag }}..."
+        if gh release view "${{ inputs.tag }}" &> /dev/null; then
+          echo "::error::Release for tag ${{ inputs.tag }} already exists!"
+          exit 1
+        fi
+        
+        echo "Verifying commit author..."
+        EXPECTED_AUTHOR="${{ inputs.expected_author }}"
+        AUTHOR=$(git show -s --format='%ae' HEAD)
+        if [[ $AUTHOR != $EXPECTED_AUTHOR ]]; then
+          echo "::error::Expected author email to be '$EXPECTED_AUTHOR', but got '$AUTHOR'. Aborting release."
+          exit 1
+        fi
+        
+        echo "All checks passed: Tag exists, no release found, and author verified."
+      env:
+        GH_TOKEN: ${{ github.token }}

--- a/.github/actions/tag-release/action.yml
+++ b/.github/actions/tag-release/action.yml
@@ -1,0 +1,68 @@
+name: 'Tag Release'
+description: 'Creates a new tag or uses an existing one'
+
+inputs:
+  tag:
+    description: 'Existing tag to use (optional)'
+    required: false
+  email:
+    description: 'Email for git config and author validation'
+    required: true
+  username:
+    description: 'Username for git config'
+    required: true
+
+outputs:
+  tag:
+    description: 'The tag that was created or used'
+    value: ${{ steps.determine-tag.outputs.tag }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Determine tag
+      id: determine-tag
+      shell: bash
+      run: |
+        if [[ -n "${{ inputs.tag }}" ]]; then
+          echo "Using provided tag: ${{ inputs.tag }}"
+          echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+          echo "is_new_tag=false" >> $GITHUB_OUTPUT
+        else
+          echo "No tag provided, will create a new one"
+          echo "is_new_tag=true" >> $GITHUB_OUTPUT
+          
+          # Verify author
+          EXPECTED_AUTHOR="${{ inputs.email }}"
+          AUTHOR=$(git show -s --format='%ae' HEAD)
+          if [[ $AUTHOR != $EXPECTED_AUTHOR ]]; then
+            echo "ERROR: Expected author email to be '$EXPECTED_AUTHOR', but got '$AUTHOR'. Aborting release."
+            exit 1
+          else
+            echo "Verified author email ($AUTHOR) is as expected ($EXPECTED_AUTHOR)"
+          fi
+          
+          # Configure git
+          git config user.name "${{ inputs.username }}"
+          git config user.email "${{ inputs.email }}"
+          
+          COMMIT_TITLE=$(git show -s --format='%s' HEAD)
+          NEXT_SEMVER=$(python -c 'import sys, re; print(re.match(r"chore\(release\): ([0-9]+\.[0-9]+\.[0-9]+).*", sys.argv[1]).group(1))' "$COMMIT_TITLE")
+          
+          # The format of the tag must match the pattern in pyproject.toml -> tool.semantic_release.tag_format
+          TAG="$NEXT_SEMVER"
+          
+          # Fetch all tags to make sure we have the latest
+          git fetch --tags
+          
+          # Check if tag already exists
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping tag creation"
+          else
+            echo "Creating new tag $TAG"
+            git tag -a $TAG -m "Release $TAG"
+            git push origin $TAG
+          fi
+          
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+        fi

--- a/.github/workflows/reusable_bump.yml
+++ b/.github/workflows/reusable_bump.yml
@@ -34,7 +34,7 @@ jobs:
           git config --local user.email ${{secrets.EMAIL}}
           git config --local user.name ${{secrets.USER}}
 
-      - name: Bump
+      - name: NextSemver
         run: |
           BUMP_ARGS=""
           if [[ "${{ inputs.force_version_bump }}" != "" ]]; then
@@ -50,14 +50,19 @@ jobs:
           hatch env create release
           hatch run release:deps
           NEXT_SEMVER=$(hatch run release:bump $BUMP_ARGS)
+          echo "NEXT_SEMVER=$NEXT_SEMVER" >> $GITHUB_ENV
+          git checkout -b bump/$NEXT_SEMVER
 
+
+      - name: GenerateChangeLog
+        run: |
           # Grab the new version's changelog and prepend it to the original changelog contents
           python .github/scripts/get_latest_changelog.py > NEW_LOG.md
           cat NEW_LOG.md CHANGELOG.bak.md > CHANGELOG.md
           rm NEW_LOG.md
 
-          git checkout -b bump/$NEXT_SEMVER
           git add CHANGELOG.md
+
           git commit -sm "chore(release): $NEXT_SEMVER"
 
           echo "NEXT_SEMVER=$NEXT_SEMVER" >> $GITHUB_ENV

--- a/.github/workflows/reusable_prerelease.yml
+++ b/.github/workflows/reusable_prerelease.yml
@@ -1,0 +1,37 @@
+name: "Prerelease"
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+
+
+jobs:
+  PreRelease:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{inputs.tag}}
+          fetch-depth: 0
+          token: ${{ secrets.CI_TOKEN }}
+
+      - name: Build
+        run: |
+          pip install --upgrade hatch
+          hatch -v build
+
+      - name: UploadArtifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact
+          path: |
+            dist
+            dist_extras

--- a/.github/workflows/reusable_publish_python.yml
+++ b/.github/workflows/reusable_publish_python.yml
@@ -1,0 +1,29 @@
+name: "Publish Python Package"
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+        
+jobs:
+  PublishToCodeArtifact:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_PUBLISH_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+
+      - name: Run CodeBuild
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: ${{ github.event.repository.name }}-release-Publish
+          hide-cloudwatch-logs: true
+          source-version-override: refs/tags/${{inputs.tag}}

--- a/.github/workflows/reusable_python_build.yml
+++ b/.github/workflows/reusable_python_build.yml
@@ -9,6 +9,9 @@ on:
       commit:
         required: false
         type: string
+      ref:
+        required: false
+        type: string
       python-version:
         required: true
         type: string
@@ -38,6 +41,11 @@ jobs:
       if: ${{ inputs.commit }}
       with:
         ref: ${{ inputs.commit }}
+
+    - uses: actions/checkout@v4
+      if: ${{ inputs.ref }}
+      with:
+        ref: ${{ inputs.ref }}
 
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/reusable_release.yml
+++ b/.github/workflows/reusable_release.yml
@@ -1,0 +1,71 @@
+name: "Github Release"
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+
+
+jobs:
+  Release:
+    runs-on: ubuntu-latest
+    name: Release
+    permissions:
+      id-token: write
+      contents: write
+    environment: release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{inputs.tag}}
+          fetch-depth: 0
+          token: ${{ secrets.CI_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Download
+        uses: actions/download-artifact@v4
+        
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PGP_KEY_SECRET_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+
+      - name: Import PGP Key
+        run: |
+          export SECRET_STRING="$(aws secretsmanager get-secret-value --secret-id ${{ secrets.AWS_PGP_KEY_SECRET }} --query 'SecretString')"
+          printenv SECRET_STRING | jq -r '. | fromjson | .PrivateKey' | gpg --batch --pinentry-mode loopback --import --armor
+
+          PGP_KEY_PASSPHRASE=$(printenv SECRET_STRING | jq -r '. | fromjson | .Passphrase')
+          echo "::add-mask::$PGP_KEY_PASSPHRASE"
+          echo "PGP_KEY_PASSPHRASE=$PGP_KEY_PASSPHRASE" >> $GITHUB_ENV
+
+      - name: Sign
+        run: |
+          shopt -s nullglob
+          for file in build-artifact/dist/* build-artifact/dist_extras/*; do
+             printenv PGP_KEY_PASSPHRASE | gpg --batch --pinentry-mode loopback --local-user ${{ secrets.PGP_USER }} --passphrase-fd 0 --output $file.sig --detach-sign $file
+             echo "Created signature file for $file"
+          done
+          shopt -u nullglob
+
+      - name: PushRelease
+        env:
+          GH_TOKEN: ${{ secrets.CI_TOKEN }}
+        run: |
+          RELEASE_NOTES=$(python .github/scripts/get_latest_changelog.py)
+          TAG=${{inputs.tag}}
+      
+          shopt -s nullglob
+          gh release create $TAG build-artifact/dist/* build-artifact/dist_extras/* --notes "$RELEASE_NOTES" 
+
+
+ 

--- a/.github/workflows/reusable_tag_release.yml
+++ b/.github/workflows/reusable_tag_release.yml
@@ -1,0 +1,42 @@
+# .github/workflows/reusable_tag_and_check.yml
+name: "Tag and Check Release"
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: false
+        type: string
+        description: "Existing tag to use (optional)"
+    outputs:
+      tag:
+        description: "The validated tag"
+        value: ${{ jobs.TagRelease.outputs.tag }}
+
+jobs:
+  TagRelease:
+    runs-on: ubuntu-latest
+    environment: release
+    outputs:
+      tag: ${{ steps.tag-release.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.sha }}
+          fetch-depth: 0
+          token: ${{ secrets.CI_TOKEN }}
+          
+      - name: Tag Release
+        id: tag-release
+        uses: aws-deadline/.github/.github/actions/tag-release@mainline
+        with:
+          tag: ${{ inputs.tag || '' }}
+          email: ${{ secrets.EMAIL }}
+          username: ${{ secrets.USER }}
+          
+      - name: Check Release
+        uses: aws-deadline/.github/.github/actions/check-release@mainline
+        with:
+          tag: ${{ steps.tag-release.outputs.tag }}
+          expected_author: ${{ secrets.EMAIL }}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Update OpenJD release workflows to support tag based releases.

### What was the solution? (How)
1. Split up the release into modular workflows. Tag, Build/Test, PreRelease, Release, Publish.
2. Add tags support to workflows
3. Add actions for tag validation/creation

### What is the impact of this change?
1. Releasing will no longer require code freezes
2. Release Process is more modular.

### How was this change tested?
Tested using a developer fork of [openjd-model-for-python](https://github.com/moorec-aws/openjd-model-for-python/actions/runs/15544888123).

### Was this change documented?
n/a

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*