### PR TITLE
ci: add pr labeling workflows

### DIFF
--- a/.github/workflows/reusable_extract_pr_details.yml
+++ b/.github/workflows/reusable_extract_pr_details.yml
@@ -1,0 +1,75 @@
+name: Extract PR Details
+
+on:
+  workflow_call:
+    inputs:
+      record_pr_workflow_id:
+        description: "Record PR workflow execution ID to download PR details"
+        required: true
+        type: number
+      artifact_name:
+        description: "Name of the artifact containing PR details"
+        required: false
+        type: string
+        default: "pr-info"
+      workflow_origin:
+        description: "Repository full name for runner integrity"
+        required: true
+        type: string
+    outputs:
+      pr_number:
+        description: "PR Number"
+        value: ${{ jobs.extract_pr_details.outputs.pr_number }}
+      pr_action:
+        description: "PR Action (opened, reopened, etc.)"
+        value: ${{ jobs.extract_pr_details.outputs.pr_action }}
+
+permissions:
+  actions: read  # For downloading artifacts
+
+jobs:
+  extract_pr_details:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.extract-pr-details.outputs.pr_number }}
+      pr_action: ${{ steps.extract-pr-details.outputs.pr_action }}
+    steps:
+      - name: Download PR artifact
+        uses: actions/github-script@v6
+        env:
+          WORKFLOW_ID: ${{ inputs.record_pr_workflow_id }}
+          ARTIFACT_NAME: ${{ inputs.artifact_name }}
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: process.env.WORKFLOW_ID
+            });
+            
+            const matchArtifact = artifacts.data.artifacts.find(artifact => 
+              artifact.name === process.env.ARTIFACT_NAME
+            );
+            
+            if (!matchArtifact) {
+              throw new Error(`Artifact '${process.env.ARTIFACT_NAME}' not found`);
+            }
+            
+            const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip'
+            });
+            
+            const fs = require('fs');
+            fs.writeFileSync('pr-info.zip', Buffer.from(download.data));
+      
+      - name: Extract PR details
+        id: extract-pr-details
+        run: |
+          unzip pr-info.zip
+          PR_NUMBER=$(cat pr-number.txt)
+          PR_ACTION=$(cat pr-action.txt)
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "pr_action=$PR_ACTION" >> $GITHUB_OUTPUT

--- a/.github/workflows/reusable_label_pr.yml
+++ b/.github/workflows/reusable_label_pr.yml
@@ -1,0 +1,28 @@
+name: Reusable Label PR
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        required: true
+        type: string
+        description: "The PR number to label"
+      label_name:
+        required: false
+        type: string
+        default: "waiting-on-maintainers"
+        description: "The label to add to the PR"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add label to PR
+        run: |
+          echo "Adding label '${{ inputs.label_name }}' to PR #${{ inputs.pr_number }}"
+          gh pr edit ${{ inputs.pr_number }} --add-label "${{ inputs.label_name }}" --repo ${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/reusable_record_pr_details.yml
+++ b/.github/workflows/reusable_record_pr_details.yml
@@ -1,0 +1,28 @@
+name: Record PR Details
+
+on:
+  workflow_call:
+    outputs:
+      artifact_name:
+        description: "The name of the artifact containing PR details"
+        value: "pr-info"
+
+permissions:
+  contents: read
+
+jobs:
+  record-pr-details:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create PR info artifact
+        run: |
+          mkdir -p ./pr-info
+          echo "${{ github.event.pull_request.number }}" > ./pr-info/pr-number.txt
+          echo "${{ github.event.action }}" > ./pr-info/pr-action.txt
+      
+      - name: Upload PR info artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-info
+          path: ./pr-info/
+          retention-days: 1


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need the ability to add labels to PRs from PRs created from forks.

### What was the solution? (How)
Three Workflows have been added to the organization:

1. reusable_record_pr_details.yml: This will record details of a PR to files using upload-artifact. These files can later be accessed by other workflows to extract the information and perform actions. This is a workaround that allows us to securely access information about a PR that was created from a forked repository without having to use PATs or `pull_request_target`.

2. reusable_extract_pr_details.yml: This workflow is used to download the artifacts generated by record pr and set outputs that can be used by other actions in workflows that are run securely within a repository context.

3. reusable_label_pr.yml: This workflow will set labels on PRs

### What is the impact of this change?

We can securley set labels on PRs, even ones from a forked repository.

### How was this change tested?

### Was this change documented?

n/a

### Is this a breaking change?

no
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*