### PR TITLE
chore: add responsed and stale prs and issues workflows

### DIFF
--- a/.github/workflows/responded.yml
+++ b/.github/workflows/responded.yml
@@ -1,0 +1,32 @@
+name: Contributor Responded
+on: 
+  workflow_call:
+    
+jobs:
+  add-reponded-to-issue:
+    # Check if an issue waiting for a contributor response has been responded to by a non-owner/non-maintainer
+    if: ${{ !github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'response-requested') && !contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association) }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add issue labels
+        run: gh issue edit "$NUMBER" --add-label "waiting-on-maintainers" --remove-label "response-requested,closing-soon"
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GH_REPO: ${{ github.repository }}
+            NUMBER: ${{ github.event.issue.number }}
+  add-reponded-to-pr:
+    # Check if a PR waiting for a contributor response has been responded to by a non-owner/non-maintainer
+    if:  ${{ github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'response-requested') && !contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association) }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Update pr labels
+        run: gh pr edit "$NUMBER" --add-label "waiting-on-maintainers" --remove-label "response-requested,no-pr-activity"
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GH_REPO: ${{ github.repository }}
+            NUMBER: ${{ github.event.issue.number }}
+            

--- a/.github/workflows/reusable_stale_prs_and_issues.yml
+++ b/.github/workflows/reusable_stale_prs_and_issues.yml
@@ -2,6 +2,11 @@ name: 'Check stale issues/PRs.'
 on: 
   workflow_call:
 
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
 jobs:
   stale-review-stage:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable_stale_prs_and_issues.yml
+++ b/.github/workflows/reusable_stale_prs_and_issues.yml
@@ -1,0 +1,29 @@
+name: 'Check stale issues/PRs.'
+on: 
+  workflow_call:
+
+jobs:
+  stale-review-stage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          debug-only: false
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          days-before-stale: 5
+          days-before-close: 10
+
+          stale-issue-message: 'Greetings! It looks like this issue hasn’t been active in more than five days. We encourage you to check if this is still an issue in the latest release. In the absence of more information, we will be closing this issue soon. If you find that this is still a problem, please feel free to provide a comment or upvote with a reaction on the initial post to prevent automatic closure. If the issue is already closed, please feel free to open a new one.'
+          stale-pr-message: 'This pull request is in the review stage. It has been 5 days with no response to feedback provided by the maintainers. Please comment with an update to indicate work you are still working on the pull request. Thanks!'
+
+          stale-issue-label: closing-soon
+          stale-pr-label: no-pr-activity
+
+          labels-to-add-when-unstale: waiting-on-maintainers
+          labels-to-remove-when-unstale: response-requested,closing-soon,no-pr-activity  
+          only-labels: response-requested
+
+          close-issue-label: closed-for-staleness
+          close-pr-label: closed-for-staleness 
+          

--- a/.github/workflows/reusable_tag_release.yml
+++ b/.github/workflows/reusable_tag_release.yml
@@ -29,14 +29,15 @@ jobs:
           
       - name: Tag Release
         id: tag-release
-        uses: aws-deadline/.github/.github/actions/tag-release@mainline
+        uses: OpenJobDescription/.github/.github/actions/tag-release@mainline
         with:
           tag: ${{ inputs.tag || '' }}
           email: ${{ secrets.EMAIL }}
           username: ${{ secrets.USER }}
           
       - name: Check Release
-        uses: aws-deadline/.github/.github/actions/check-release@mainline
+        uses: OpenJobDescription/.github/.github/actions/check-release@mainline
         with:
           tag: ${{ steps.tag-release.outputs.tag }}
           expected_author: ${{ secrets.EMAIL }}
+          


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

1. We want to add automation around detecting when contributors have responded to issues, and process around issues or prs that have staled.

2. Noticed the tagging workflow is pointing to action in the wrong organization.

3. Workflow is over permissive

### What was the solution? (How)

1. Add `reusable_stale_prs_and_issues.yml` and `responded.yml`. These workflows are copied from https://github.com/aws-deadline/.github/tree/mainline/.github/workflows.

2. Update tagging workflow to use the actions in the OpenJobDescription org.

3. restrict stale workflow to only required permissions: https://github.com/actions/stale?tab=readme-ov-file#recommended-permissions

### What is the impact of this change?
re-usable workflows are available to OpenJobDescription repositories.

### How was this change tested?
Tested in the aws-deadline repository

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*