### PR TITLE
chore: add GITHUB_TOKEN secret to stale workflow

### DIFF
--- a/.github/workflows/reusable_stale_prs_and_issues.yml
+++ b/.github/workflows/reusable_stale_prs_and_issues.yml
@@ -1,6 +1,9 @@
 name: 'Check stale issues/PRs.'
 on: 
   workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        required: true
 
 permissions:
   issues: write


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to explicitly add the secret was want to pass to the stale workflow

### What was the solution? (How)
Add the GITHUB_TOKEN secret to the workflow

### What is the impact of this change?
Scopes workflow to only need the GITHUB_TOKEN.

### How was this change tested?
n/a

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*