### PR TITLE
chore: pin the version of click that hatch uses to <8.3 due to Sentin…

### DIFF
--- a/.github/workflows/reusable_prerelease.yml
+++ b/.github/workflows/reusable_prerelease.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch "click<8.3"
           hatch -v build
 
       - name: UploadArtifacts

--- a/.github/workflows/reusable_publish.yml
+++ b/.github/workflows/reusable_publish.yml
@@ -78,7 +78,7 @@ jobs:
       # Tag must be made before building so the generated _version.py files have the correct version
       - name: Build
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch "click<8.3"
           hatch -v build
 
       - name: Configure AWS credentials
@@ -166,7 +166,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch "click<8.3"
           pip install --upgrade twine
 
       - name: Build

--- a/.github/workflows/reusable_python_build.yml
+++ b/.github/workflows/reusable_python_build.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Install Hatch
       run: |
-        pip install --upgrade hatch
+        pip install --upgrade hatch "click<8.3"
 
     - name: Run Linting
       run: hatch -v run lint


### PR DESCRIPTION
related: aws-deadline/.github#56

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
