### PR TITLE
chore: fix semantic versioning command for 10.4

### DIFF
--- a/.github/workflows/reusable_bump.yml
+++ b/.github/workflows/reusable_bump.yml
@@ -49,10 +49,7 @@ jobs:
           pip install -r requirements-release.txt
           
           # Run semantic-release to generate new changelog
-          NEXT_SEMVER=$(semantic-release -v --strict version --no-push --no-tag --skip-build $BUMP_ARGS)
-
-          # Reset the semantic-release commit but keep the file changes
-          git reset --soft HEAD~1
+          NEXT_SEMVER=$(semantic-release -v --strict version --no-commit --no-push --no-tag $BUMP_ARGS)
 
           echo "NEXT_SEMVER=$NEXT_SEMVER" >> $GITHUB_ENV
           git checkout -b bump/$NEXT_SEMVER


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
semantic versioning fixed a bug that was forcing a commit/sha

### What was the solution? (How)
Remove workaround that was in place

### What is the impact of this change?
Supports python semantic version 10.4

### How was this change tested?

https://github.com/moorec-aws/deadline-cloud-for-blender/actions/runs/17747173226

### Was this change documented?
n/a

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
