### PR TITLE
fix: patch version in sdist release build too

### DIFF
--- a/.github/workflows/reusable_maturin_prerelease.yml
+++ b/.github/workflows/reusable_maturin_prerelease.yml
@@ -81,6 +81,16 @@ jobs:
           ref: refs/tags/${{ inputs.tag }}
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Inject version
+        if: inputs.version-script != ''
+        run: ${{ inputs.version-script }}
+        shell: bash
+
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Release publish to PyPI failed due to wrong package version in sdist:

Release version is 0.10.0, but sdist had an outdated version of 0.9.0

```
Uploading openjd_model-0.10.0-cp39-abi3-win_arm64.whl
INFO     Response from https://upload.pypi.org/legacy/:                         
         200 OK                                                                 
INFO     <html>                                                                 
          <head>                                                                
           <title>200 OK</title>                                                
          </head>                                                               
          <body>                                                                
           <h1>200 OK</h1>                                                      
           <br/><br/>                                                           
                                                                                
                                                                                
                                                                                
          </body>                                                               
         </html>                                                                
Uploading openjd_model-0.9.0.tar.gz
INFO     Response from https://upload.pypi.org/legacy/:                         
         400 Bad Request                                                        
INFO     <html>                                                                 
          <head>                                                                
           <title>400 File already exists ('openjd_model-0.9.0.tar.gz', with    
         blake2_256 hash                                                        
         'd2839c268fad3a67b26a042f58d6e874d22810abd45a87f7e873ebf9bdda7098').   
         See https://pypi.org/help/#file-name-reuse for more                    
         information.</title>                                                   
          </head>                                                               
          <body>                                                                
           <h1>400 File already exists ('openjd_model-0.9.0.tar.gz', with       
         blake2_256 hash                                                        
         'd2839c268fad3a67b26a042f58d6e874d22810abd45a87f7e873ebf9bdda7098').   
         See https://pypi.org/help/#file-name-reuse for more information.</h1>  
           The server could not comply with the request since it is either      
         malformed or otherwise incorrect.<br/><br/>                            
         File already exists (&#x27;openjd_model-0.9.0.tar.gz&#x27;, with       
         blake2_256 hash                                                        
         &#x27;d2839c268fad3a67b26a042f58d6e874d22810abd45a87f7e873ebf9bdda7098&
         #x27;). See https://pypi.org/help/#file-name-reuse for more            
         information.                                                           
                                                                                
                                                                                
          </body>                                                               
         </html>                                                                
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
         Bad Request      
```

### What was the solution? (How)

Patch the version in the sdist build too

### What is the impact of this change?

Release publish to PyPI succeeds

### How was this change tested?

N/A - will resume the release or rerun it

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*