### PR TITLE
fix: upload correct artifact structure in maturin prerelease workflow

### DIFF
--- a/.github/workflows/reusable_maturin_prerelease.yml
+++ b/.github/workflows/reusable_maturin_prerelease.yml
@@ -117,7 +117,15 @@ jobs:
       - name: List artifacts
         run: ls -la dist/
 
+      # Create dist_extras so upload-artifact sees multiple paths.
+      # This forces it to use the workspace root as the common ancestor,
+      # preserving "dist/" in the artifact (matching reusable_release.yml's
+      # build-artifact/dist/* glob). A single path strips the directory name.
+      - run: mkdir -p dist_extras
+
       - uses: actions/upload-artifact@v4
         with:
           name: build-artifact
-          path: dist
+          path: |
+            dist
+            dist_extras


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The GitHub Release portion of the release workflow was not uploading the release artifacts, as seen in OJD model release 0.10.0 https://github.com/OpenJobDescription/openjd-model-for-python/releases/tag/0.10.0

Root cause is the release artifact file layout was changed with the new build system and the `dist` folder is no longer included in the downloaded release artifacts

### What was the solution? (How)
Force the `dist_extras` dir to exist so the `dist` folder is included in the downloaded artifacts of the Release flow

### What is the impact of this change?
GitHub release has the release artifacts

### How was this change tested?
On my fork with a test workflow: https://github.com/jericht/openjd-model-for-python/actions/runs/28186969048

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*