### PR TITLE
fix: pass GitHub event context via env vars in reusable workflow

### DIFF
--- a/.github/workflows/reusable_record_pr_details.yml
+++ b/.github/workflows/reusable_record_pr_details.yml
@@ -15,10 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create PR info artifact
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_ACTION: ${{ github.event.action }}
         run: |
           mkdir -p ./pr-info
-          echo "${{ github.event.pull_request.number }}" > ./pr-info/pr-number.txt
-          echo "${{ github.event.action }}" > ./pr-info/pr-action.txt
+          echo "$PR_NUMBER" > ./pr-info/pr-number.txt
+          echo "$PR_ACTION" > ./pr-info/pr-action.txt
       
       - name: Upload PR info artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The `Record PR Details` reusable workflow interpolated `github.event.*` values directly into an inline `run:` script.

### What was the solution? (How)
Move the `github.event.*` values (`pull_request.number`, `event.action`) out of the inline `run:` script and into an `env:` block, so they are referenced as shell variables rather than templated into the script text.

### What is the impact of this change?
No behavioral change — the artifact contents are identical. This is a small workflow-hygiene cleanup that keeps the pattern consistent with the other reusable workflows (e.g. `responded.yml`) and with the equivalent workflow in `aws-deadline/.github` (https://github.com/aws-deadline/.github/pull/87).

### How was this change tested?
YAML validated locally. The values consumed are unchanged; only how they are passed to the shell differs.

### Was this change documented?
n/a

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*