### PR TITLE
fix: separate version injection commands to unblock release

### DIFF
--- a/.github/workflows/reusable_maturin_prerelease.yml
+++ b/.github/workflows/reusable_maturin_prerelease.yml
@@ -22,13 +22,21 @@ on:
             { "os": "macos-latest",   "target": "aarch64-apple-darwin" },
             { "os": "macos-15-intel", "target": "x86_64-apple-darwin" }
           ]
+      version-script-deps:
+        required: false
+        type: string
+        description: >
+          Pip packages to install before running the version script.
+          Space-separated. Skipped if empty.
+        default: "setuptools_scm"
       version-script:
         required: false
         type: string
         description: >
-          Shell command to inject VCS version before building.
+          Command to inject VCS version before building.
+          Must be a simple command (no shell operators like && || ;).
           Run in bash. Skipped if empty.
-        default: "pip install setuptools_scm && python scripts/maturin_build.py --version-only"
+        default: "python scripts/maturin_build.py --version-only"
 
 jobs:
   BuildWheels:
@@ -50,6 +58,13 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
+
+      - name: Install version script dependencies
+        if: inputs.version-script-deps != ''
+        env:
+          DEPS: ${{ inputs.version-script-deps }}
+        run: "pip install $DEPS"
+        shell: bash
 
       - name: Inject version
         if: inputs.version-script != ''
@@ -87,6 +102,13 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
+
+      - name: Install version script dependencies
+        if: inputs.version-script-deps != ''
+        env:
+          DEPS: ${{ inputs.version-script-deps }}
+        run: "pip install $DEPS"
+        shell: bash
 
       - name: Inject version
         if: inputs.version-script != ''


### PR DESCRIPTION
  ### What was the problem/requirement? (What/Why)
  
The security hardening in #21 moved `${{ inputs.version-script }}` from `run:` into an env var to prevent script injection (zizmor). However, the default value contains `&&` which is not re-parsed as a shell operator when expanded from a variable — bash treats it as a  literal argument. This broke the InjectVersion step for all consumers on all platforms.

Example openjd-model release: https://github.com/OpenJobDescription/openjd-model-for-python/actions/runs/28989508762
  
  ### What was the solution? (How)
  
  Split the single `version-script` input into two: `version-script-deps` (pip packages to install) and `version-script` (simple command to run). Each gets its own step. No compound shell operators needed in variables.
  
  ### What is the impact of this change?
  
  Fixes the release workflow for all repos using this reusable workflow. Callers relying on the defaults (like openjd-model-for-python) need no changes. Callers that override `version-script` with a compound command will need to split their input across the two new inputs.
  
  ### How was this change tested?
  
  Reproduced locally:
  
```
$ echo '$VERSION_SCRIPT' > /tmp/test.sh
$ VERSION_SCRIPT='pip install setuptools_scm && python scripts/maturin_build.py --version-only' \
>     bash --noprofile --norc -eo pipefail /tmp/test.sh

[optparse.groups]Usage:[/]   
  pip install \[options] <requirement specifier> \[package-index-options] ...
  pip install \[options] -r <requirements file> \[package-index-options] ...
  pip install \[options] [-e] <vcs project url> ...
  pip install \[options] [-e] <local project path> ...
  pip install \[options] <archive url/path> ...

no such option: --version-only
```  

  Confirmed the split approach works:
  
```
$ echo '$VERSION_SCRIPT' > /tmp/step2.sh
$ VERSION_SCRIPT='python scripts/maturin_build.py --version-only' bash --noprofile --norc -eo pipefail /tmp/step2.sh
Wrote src/openjd/model/_version.py (version 0.10.1.post10+gf377934)
Patched pyproject.toml: project.version = '0.10.1.post10+gf377934'
```  

  ### Was this change documented?
  
  Input descriptions updated in the workflow file.
  
  ### Is this a breaking change?
  
  Yes for callers that override `version-script` with a compound command — they must split across the two new inputs. Callers using
  defaults are unaffected.
  
  ----
  
  *By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your
  choice.*